### PR TITLE
Remove incorrect expression generated by AI

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,6 @@ const sortedRepos = modules;
 			</h1>
 			<p class="text-lg text-gray-600 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed">
 				Explore a curated collection of modules to enhance your device. 
-				Secure, open-source, and easy to install.
 			</p>
 		</div>
 


### PR DESCRIPTION
Removed the installation description from the index page to streamline content.